### PR TITLE
Manifest v4! This is... big.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Advanced Backups 
 [![](https://img.shields.io/curseforge/dt/876284?label=downloads&style=for-the-badge&logo=curseforge&color=2D2D2D)](https://www.curseforge.com/minecraft/mc-mods/advanced-backups) [![](https://img.shields.io/modrinth/dt/Jrmoreqs?label=downloads&style=for-the-badge&logo=modrinth&color=2D2D2D)](https://modrinth.com/mod/advanced-backups) [![](https://img.shields.io/badge/discord-2D2D2D?style=for-the-badge&logo=discord)](https://discord.gg/SxN7JtzUyX)
 
+- Marker just to make a pr possible. shhhh
+
 A powerful backup mod for Minecraft, supporting Neoforge, Forge and Fabric.
 Many Minecraft versions are supported - request more if the one you want isn't yet supported.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Advanced Backups 
 [![](https://img.shields.io/curseforge/dt/876284?label=downloads&style=for-the-badge&logo=curseforge&color=2D2D2D)](https://www.curseforge.com/minecraft/mc-mods/advanced-backups) [![](https://img.shields.io/modrinth/dt/Jrmoreqs?label=downloads&style=for-the-badge&logo=modrinth&color=2D2D2D)](https://modrinth.com/mod/advanced-backups) [![](https://img.shields.io/badge/discord-2D2D2D?style=for-the-badge&logo=discord)](https://discord.gg/SxN7JtzUyX)
 
-- Marker just to make a pr possible. shhhh
-
 A powerful backup mod for Minecraft, supporting Neoforge, Forge and Fabric.
 Many Minecraft versions are supported - request more if the one you want isn't yet supported.
 

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/BackupWrapper.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/BackupWrapper.java
@@ -340,8 +340,6 @@ public class BackupWrapper {
     public static void finishBackup(boolean snapshot) {
         
         ABCore.resetActivity();
-
-        System.out.println("Snapshot : " + snapshot);
         
         if (snapshot) return;
         
@@ -361,8 +359,6 @@ public class BackupWrapper {
             }
             
         }
-        
-        System.out.println("Beginning purge checks : " + directory.toString());
         
         checkSize(directory);
         checkCount(directory);
@@ -429,10 +425,10 @@ public class BackupWrapper {
     }
     
     private static void checkCount(File directory) {
-        if (ConfigManager.backupsToKeep.get() <= 0) { System.out.println("Backup count check disabled"); return;}
+        if (ConfigManager.backupsToKeep.get() <= 0) return;
         long date = 0;
         while (true) {
-            if (calculateBackupCount(directory) <= ConfigManager.backupsToKeep.get()) { System.out.println("Backup count under configured size"); return;}
+            if (calculateBackupCount(directory) <= ConfigManager.backupsToKeep.get()) return;
             File file = getFirstBackupAfterDate(directory, date);
             File dependent = getDependent(file);
             if (dependent == null) {

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/ThreadedBackup.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/ThreadedBackup.java
@@ -519,7 +519,7 @@ public class ThreadedBackup extends Thread {
             for (String backupName : file.list()) {
                 if (backupName.contains("incomplete")) {
                     File file2 = new File(file, backupName);
-                    File file3 = new File(file, backupName.replace("incomplete", "backup"));
+                    File file3 = new File(file, backupName.replace("incomplete", "backupv4"));
                     file2.renameTo(file3);
                 }
             }

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/ThreadedBackup.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/backups/ThreadedBackup.java
@@ -49,6 +49,7 @@ public class ThreadedBackup extends Thread {
     private ArrayList<String> erroringFiles = new ArrayList<>();
 
     public static final ArrayList<Pattern> blacklist = new ArrayList<>();
+    public static final ArrayList<Pattern> whitelist = new ArrayList<>();
 
     static {
         builder.setPrettyPrinting();

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
@@ -35,9 +35,8 @@ public class ConfigManager {
     public static final LongValue buffer = new LongValue("config.advancedbackups.buffer", 1048576, 1024, Integer.MAX_VALUE, ConfigManager::register); //5mb
     public static final BooleanValue flush  = new BooleanValue("config.advancedbackups.flush", false, ConfigManager::register);
     public static final BooleanValue activity = new BooleanValue("config.advancedbackups.activity", true, ConfigManager::register);
-    //The whitelist is ${worldfolder}* rather than ${worldfolder}/* to also grab non-overworld dimensions in plugin setups that separate them.
-    public static final StringArrayValue whitelist = new StringArrayValue("config.advancedbackups.whitelist", new String[] {"${worldfolder}*"}, ConfigManager::register);
-    public static final StringArrayValue blacklist = new StringArrayValue("config.advancedbackups.blacklist", new String[] {"${worldfolder}/session.lock","${worldfolder}/*_old"}, ConfigManager::register);
+    public static final StringArrayValue whitelist = new StringArrayValue("config.advancedbackups.whitelist", new String[] {"${worldfolder}", "${worldfolder}_nether", "${worldfolder}_the_end"}, ConfigManager::register);
+    public static final StringArrayValue blacklist = new StringArrayValue("config.advancedbackups.blacklist", new String[] {"*session.lock","*_old"}, ConfigManager::register);
     public static final ValidatedStringValue type = new ValidatedStringValue("config.advancedbackups.type", "differential", new String[]{"zip", "differential", "incremental"}, ConfigManager::register);
     public static final FreeStringValue path = new FreeStringValue("config.advancedbackups.path", "./backups", ConfigManager::register);
     public static final FloatValue minFrequency = new FloatValue("config.advancedbackups.frequency.min", 0.25F, 0F, 500F, ConfigManager::register);

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
@@ -189,10 +189,23 @@ public class ConfigManager {
         for (String string : blacklist.get()) {
 
             string = string.replace("\\", "/");
+            string = string.replace("${worldpath}", ABCore.worldDir.toString());
             string = string.replaceAll("[^a-zA-Z0-9*]", "\\\\$0");
             string = "^" + string.replace("*", ".*") + "$";
 
             ThreadedBackup.blacklist.add(Pattern.compile(string, Pattern.CASE_INSENSITIVE));            
+        }
+
+        ThreadedBackup.whitelist.clear();
+
+        for (String string : whitelist.get()) {
+
+            string = string.replace("\\", "/");
+            string = string.replace("${worldpath}", ABCore.worldDir.toString());
+            string = string.replaceAll("[^a-zA-Z0-9*]", "\\\\$0");
+            string = "^" + string.replace("*", ".*") + "$";
+
+            ThreadedBackup.whitelist.add(Pattern.compile(string, Pattern.CASE_INSENSITIVE));            
         }
         
 

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
@@ -35,7 +35,7 @@ public class ConfigManager {
     public static final LongValue buffer = new LongValue("config.advancedbackups.buffer", 1048576, 1024, Integer.MAX_VALUE, ConfigManager::register); //5mb
     public static final BooleanValue flush  = new BooleanValue("config.advancedbackups.flush", false, ConfigManager::register);
     public static final BooleanValue activity = new BooleanValue("config.advancedbackups.activity", true, ConfigManager::register);
-    public static final StringArrayValue whitelist = new StringArrayValue("config.advancedbackups.whitelist", new String[] {"${worldfolder}", "${worldfolder}_nether", "${worldfolder}_the_end"}, ConfigManager::register);
+    public static final StringArrayValue whitelist = new StringArrayValue("config.advancedbackups.whitelist", new String[] {"?{worldfolder}", "?{worldfolder}_nether", "?{worldfolder}_the_end"}, ConfigManager::register);
     public static final StringArrayValue blacklist = new StringArrayValue("config.advancedbackups.blacklist", new String[] {"*session.lock","*_old"}, ConfigManager::register);
     public static final ValidatedStringValue type = new ValidatedStringValue("config.advancedbackups.type", "differential", new String[]{"zip", "differential", "incremental"}, ConfigManager::register);
     public static final FreeStringValue path = new FreeStringValue("config.advancedbackups.path", "./backups", ConfigManager::register);

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
@@ -35,7 +35,9 @@ public class ConfigManager {
     public static final LongValue buffer = new LongValue("config.advancedbackups.buffer", 1048576, 1024, Integer.MAX_VALUE, ConfigManager::register); //5mb
     public static final BooleanValue flush  = new BooleanValue("config.advancedbackups.flush", false, ConfigManager::register);
     public static final BooleanValue activity = new BooleanValue("config.advancedbackups.activity", true, ConfigManager::register);
-    public static final StringArrayValue blacklist = new StringArrayValue("config.advancedbackups.blacklist", new String[] {"session.lock","*_old"}, ConfigManager::register);
+    //The whitelist is ${worldfolder}* rather than ${worldfolder}/* to also grab non-overworld dimensions in plugin setups that separate them.
+    public static final StringArrayValue whitelist = new StringArrayValue("config.advancedbackups.whitelist", new String[] {"${worldfolder}*"}, ConfigManager::register);
+    public static final StringArrayValue blacklist = new StringArrayValue("config.advancedbackups.blacklist", new String[] {"${worldfolder}/session.lock","${worldfolder}/*_old"}, ConfigManager::register);
     public static final ValidatedStringValue type = new ValidatedStringValue("config.advancedbackups.type", "differential", new String[]{"zip", "differential", "incremental"}, ConfigManager::register);
     public static final FreeStringValue path = new FreeStringValue("config.advancedbackups.path", "./backups", ConfigManager::register);
     public static final FloatValue minFrequency = new FloatValue("config.advancedbackups.frequency.min", 0.25F, 0F, 500F, ConfigManager::register);

--- a/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
+++ b/src/main/java/co/uk/mommyheather/advancedbackups/core/config/ConfigManager.java
@@ -200,8 +200,8 @@ public class ConfigManager {
 
         for (String string : whitelist.get()) {
 
+            string = string.replace("?{worldfolder}", ABCore.worldDir.getParent().toString());
             string = string.replace("\\", "/");
-            string = string.replace("${worldpath}", ABCore.worldDir.toString());
             string = string.replaceAll("[^a-zA-Z0-9*]", "\\\\$0");
             string = "^" + string.replace("*", ".*") + "$";
 

--- a/src/main/resources/advancedbackups-properties.txt
+++ b/src/main/resources/advancedbackups-properties.txt
@@ -25,8 +25,17 @@ config.advancedbackups.activity
 config.advancedbackups.type
 
 #A list of files, relative paths within the world directory, to skip backing up.
+#The blacklist has priority.
 #Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
-#Default : session.lock,*.dat_old
+# ${worldfolder} is a placeholder that maps to the world's folder.
+#Default : ${worldfolder}*
+config.advancedbackups.whitelist
+
+#A list of files, relative paths within the instance root directory, to skip backing up.
+#Takes priority over the whitelist.
+#Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
+# ${worldfolder} is a placeholder that maps to the world's folder.
+#Default : ${worldfolder}/session.lock,${worldfolder}/*.dat_old
 config.advancedbackups.blacklist
 
 #The absolute or relative path to the backup location.

--- a/src/main/resources/advancedbackups-properties.txt
+++ b/src/main/resources/advancedbackups-properties.txt
@@ -27,14 +27,14 @@ config.advancedbackups.type
 #A list of files, relative paths within the world directory, to skip backing up.
 #The blacklist has priority.
 #Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
-# ${worldfolder} is a placeholder that maps to the world's folder.
-#Default : ${worldfolder},${worldfolder}_nether,${worldfolder}_end
+# ?{worldfolder} is a placeholder that maps to the world's folder.
+#Default : ?{worldfolder},?{worldfolder}_nether,?{worldfolder}_end
 config.advancedbackups.whitelist
 
 #A list of files, relative paths within the instance root directory, to skip backing up.
 #Takes priority over the whitelist.
 #Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
-# ${worldfolder} is a placeholder that maps to the world's folder.
+# ?{worldfolder} is a placeholder that maps to the world's folder.
 #Default : *session.lock,*.dat_old
 config.advancedbackups.blacklist
 

--- a/src/main/resources/advancedbackups-properties.txt
+++ b/src/main/resources/advancedbackups-properties.txt
@@ -28,14 +28,14 @@ config.advancedbackups.type
 #The blacklist has priority.
 #Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
 # ${worldfolder} is a placeholder that maps to the world's folder.
-#Default : ${worldfolder}*
+#Default : ${worldfolder},${worldfolder}_nether,${worldfolder}_end
 config.advancedbackups.whitelist
 
 #A list of files, relative paths within the instance root directory, to skip backing up.
 #Takes priority over the whitelist.
 #Comma separated, * is a wildcard, and backslashes are replaced with forward slashes.
 # ${worldfolder} is a placeholder that maps to the world's folder.
-#Default : ${worldfolder}/session.lock,${worldfolder}/*.dat_old
+#Default : *session.lock,*.dat_old
 config.advancedbackups.blacklist
 
 #The absolute or relative path to the backup location.


### PR DESCRIPTION
Manifest V4 has a few changes planned, yet these will be a LOT of work:

- Vastly improve backup preparation times ( #78 )

- Change the backup strategy, so a backup root is treated as the server / instance root rather than the world root
   - By default, this won't change much - other than where you have to extract a backup to.
   - It'll however allow for some new features, which will be described below.
   - This of course does require some heavy changes to the automated backup restoration, which is part of why this is happening *before* the gui is made.
   
 - Add a file *whitelist* feature. This will work as such:
   - Files on the whitelist will be added to the backup.
   - The existing blacklist feature will take priority - that is, if you whitelist the entire config folder, but blacklist a specific config file, then all configs *except* that file will be backed up.
   - The default whitelist will be the world's own folder, with a wildcard at the end - this will allow for setups that separate each dimension into their own folder to be backed up correctly. 
   - A placeholder will be usable here and in the blacklist - `?{worldfolder}*` would be the syntax for the above point. You could, say, blacklist `?{worldfolder}/level.dat` to prevent the world's level.dat from being backed up.